### PR TITLE
Add JUnit test for Config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,12 +61,15 @@ minecraft {
 sourceSets.main.resources { srcDir 'src/generated/resources' }
 
 repositories {
+    mavenCentral()
     maven { url 'https://dl.cloudsmith.io/public/geckolib3/geckolib/maven/' }
 }
 
 dependencies {
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
     implementation fg.deobf('software.bernie.geckolib:geckolib-forge-1.19.4:4.1.3')
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.2'
 }
 
 tasks.named('processResources', ProcessResources).configure {
@@ -115,4 +118,8 @@ publishing {
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
+}
+
+tasks.named('test', Test).configure {
+    useJUnitPlatform()
 }

--- a/src/test/java/com/mod/chinschilamod/ConfigTest.java
+++ b/src/test/java/com/mod/chinschilamod/ConfigTest.java
@@ -1,0 +1,26 @@
+package com.mod.chinschilamod;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ConfigTest {
+
+    private static boolean invokeValidateItemName(String name) throws Exception {
+        Method m = Config.class.getDeclaredMethod("validateItemName", Object.class);
+        m.setAccessible(true);
+        return (Boolean) m.invoke(null, name);
+    }
+
+    @Test
+    public void testValidItem() throws Exception {
+        assertTrue(invokeValidateItemName("minecraft:iron_ingot"));
+    }
+
+    @Test
+    public void testInvalidItem() throws Exception {
+        assertFalse(invokeValidateItemName("minecraft:nonexistent_item"));
+    }
+}


### PR DESCRIPTION
## Summary
- add JUnit dependencies and enable `useJUnitPlatform`
- add tests for `Config.validateItemName`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685da939a5fc83309597d6802d8d224e